### PR TITLE
[ci skip] [skip ci] ***NO_CI*** Update maintainers, remove conda-forge/napari

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,4 +198,4 @@ Feedstock Maintainers
 =====================
 
 * [@goanpeca](https://github.com/goanpeca/)
-
+* [@jaimergp](https://github.com/jaimergp/)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -51,3 +51,4 @@ about:
 extra:
   recipe-maintainers:
     - goanpeca
+    - jaimergp


### PR DESCRIPTION
The `conda-forge/napari` team was initially added as a way to support the migration to conda-forge.

The situation is now stable and we can prevent unwanted notifications by only leaving a subset of the team listed explicitly as maintainers.